### PR TITLE
Fix: Use GITHUB_TOKEN for checkout in auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Changed the auto-tag workflow to use the standard `secrets.GITHUB_TOKEN` instead of `secrets.PAT_TOKEN` for the `actions/checkout` step. This resolves an issue where the token might not be correctly supplied, causing the workflow to fail.