### PR TITLE
Fix old repo name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 Licensed under MIT License. See [LICENSE](LICENSE) for details.
 
-- 🐛 **Issues & Features**: [GitHub Issues](https://github.com/stephtanner1/Cost%20Per%20Point/issues)
+- 🐛 **Issues & Features**: [GitHub Issues](https://github.com/stephtanner1/Cents-Per-Point/issues)
 - 📖 **Detailed Docs**: [Deployment Guide](DEPLOYMENT.md)
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,7 +6,7 @@
 
 ```bash
 # Download and start - that's it!
-curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cost%20Per%20Point/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cents-Per-Point/main/docker-compose.yml
 docker-compose up -d
 ```
 
@@ -16,7 +16,7 @@ If you have existing SQLite data in a Docker volume:
 
 ```bash
 # Download the compose file
-curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cost%20Per%20Point/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cents-Per-Point/main/docker-compose.yml
 
 # Edit the file to uncomment the volume lines:
 # In the backend service, uncomment:
@@ -114,7 +114,7 @@ your-deployment/
 
 ```bash
 # Download and run - no editing needed
-curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cost%20Per%20Point/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cents-Per-Point/main/docker-compose.yml
 docker-compose up -d
 ```
 
@@ -122,7 +122,7 @@ docker-compose up -d
 
 ```bash
 # Download compose file
-curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cost%20Per%20Point/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cents-Per-Point/main/docker-compose.yml
 
 # Edit to uncomment volume lines (replace 'backend_data' with your volume name):
 # Backend service volumes section
@@ -161,7 +161,7 @@ docker-compose up -d
 
 ```bash
 # Download new compose file
-curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cost%20Per%20Point/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/stephtanner1/Cents-Per-Point/main/docker-compose.yml
 
 # Uncomment volume lines for your SQLite data
 # (edit docker-compose.yml)

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -73,7 +73,7 @@ When a version tag (e.g., `v0.1.0`) is pushed:
 ## Release Notes
 
 Release notes are maintained in GitHub Releases, accessible at:
-https://github.com/[username]/Cost%20Per%20Point/releases
+https://github.com/[username]/Cents-Per-Point/releases
 
 ## Example Release Workflow
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cost Per Point",
+  "name": "Cents-Per-Point",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## Summary
- update README support link to new repository name
- update deployment docs to new URL
- update versioning docs with new repository name
- update package-lock metadata to new package name

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm test` in backend *(fails: Missing script)*
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68450c5497f8832b866673d052fe9a1b