### PR TITLE
Fix missing eslint dependency

### DIFF
--- a/frontend-vite/package-lock.json
+++ b/frontend-vite/package-lock.json
@@ -18,6 +18,7 @@
         "recharts": "^2.10.3"
       },
       "devDependencies": {
+        "@eslint/js": "^8.57.1",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@vitejs/plugin-react": "^4.2.0",

--- a/frontend-vite/package.json
+++ b/frontend-vite/package.json
@@ -25,6 +25,7 @@
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.53.0",
+    "@eslint/js": "^8.57.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",
     "postcss": "^8.4.31",


### PR DESCRIPTION
## Summary
- add `@eslint/js` to frontend dev dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68450c9093c8832bbb350383dbe79f8d