### PR TITLE
Fix dev-stop reminder

### DIFF
--- a/scripts/dev-stop.sh
+++ b/scripts/dev-stop.sh
@@ -12,4 +12,4 @@ echo "🐘 Stopping PostgreSQL container..."
 docker-compose stop postgres
 
 echo "✅ All services stopped!"
-echo "💡 Run ./dev.sh to start the development environment again" 
+echo "💡 Run 'docker-compose up -d' to start the development environment again"


### PR DESCRIPTION
## Summary
- fix docs to reference the real command to start dev environment

## Testing
- `od -c scripts/dev-stop.sh | tail`

------
https://chatgpt.com/codex/tasks/task_b_68450c9fa240832bbff28a18baa6890e