### PR TITLE
Add backend route tests and CI coverage

### DIFF
--- a/.github/workflows/backend-compose.yml
+++ b/.github/workflows/backend-compose.yml
@@ -1,0 +1,44 @@
+name: Backend Compose Tests
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/backend-compose.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Start services
+        run: docker compose -f docker-compose.yml up -d postgres
+      - name: Wait for Postgres
+        run: |
+          for i in {1..15}; do
+            docker exec $(docker compose ps -q postgres) pg_isready -U postgres && break
+            sleep 2
+          done
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+      - name: Run tests
+        run: npm test -- --coverage
+        working-directory: backend
+        env:
+          DB_HOST: localhost
+          DB_NAME: cpp_database
+          DB_USER: postgres
+          DB_PASSWORD: securepassword123
+          DB_PORT: 5432
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          flags: backend
+      - name: Shutdown
+        if: always()
+        run: docker compose -f docker-compose.yml down

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,3 +1,5 @@
 export default {
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test/jest.setup.js'],
+  maxWorkers: 1
 };

--- a/backend/test/import-export.routes.test.js
+++ b/backend/test/import-export.routes.test.js
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import { app } from '../src/index.js';
+import { initDb, getDb, closeDb } from '../src/db.js';
+
+const csvData = `date,source,points,value,taxes,notes,is_travel_credit\n2024-02-01,Test Card,1500,25,1,imported,false\n`;
+const mappings = { date: 0, source: 1, points: 2, value: 3, taxes: 4, notes: 5, is_travel_credit: 6 };
+
+beforeAll(async () => {
+  await initDb();
+  const pool = await getDb();
+  await pool.query('TRUNCATE TABLE redemptions');
+});
+
+afterAll(async () => {
+  const pool = await getDb();
+  await pool.query('DROP TABLE IF EXISTS redemptions');
+  await closeDb();
+});
+
+describe('Import/Export routes', () => {
+  it('provides a CSV template', async () => {
+    const res = await request(app).get('/api/import-export/template');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('date,source,points');
+  });
+
+  it('analyzes a CSV file', async () => {
+    const res = await request(app)
+      .post('/api/import-export/analyze')
+      .attach('csvFile', Buffer.from(csvData), 'sample.csv');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('headers');
+    expect(Array.isArray(res.body.headers)).toBe(true);
+  });
+
+  it('imports redemptions from CSV', async () => {
+    const res = await request(app)
+      .post('/api/import-export/import')
+      .field('columnMappings', JSON.stringify(mappings))
+      .attach('csvFile', Buffer.from(csvData), 'sample.csv');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.imported).toBe(1);
+  });
+
+  it('exports redemptions as CSV', async () => {
+    const res = await request(app).get('/api/import-export/export');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('date,source,points');
+  });
+});

--- a/backend/test/jest.setup.js
+++ b/backend/test/jest.setup.js
@@ -1,0 +1,5 @@
+process.env.DB_HOST = 'localhost';
+process.env.DB_USER = 'postgres';
+process.env.DB_PASSWORD = 'securepassword123';
+process.env.DB_NAME = 'cpp_database';
+process.env.DB_PORT = '5432';

--- a/backend/test/redemptions.routes.test.js
+++ b/backend/test/redemptions.routes.test.js
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import { app } from '../src/index.js';
+import { initDb, getDb, closeDb } from '../src/db.js';
+
+beforeAll(async () => {
+  await initDb();
+  const pool = await getDb();
+  await pool.query('TRUNCATE TABLE redemptions');
+});
+
+afterAll(async () => {
+  const pool = await getDb();
+  await pool.query('DROP TABLE IF EXISTS redemptions');
+  await closeDb();
+});
+
+describe('Redemptions routes', () => {
+  let redemptionId;
+
+  it('creates a redemption', async () => {
+    const res = await request(app)
+      .post('/api/redemptions')
+      .send({
+        date: '2024-01-01',
+        source: 'Test Card',
+        points: 1000,
+        value: 10,
+        taxes: 0,
+        notes: 'sample',
+        is_travel_credit: false
+      });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    redemptionId = res.body.id;
+  });
+
+  it('retrieves all redemptions', async () => {
+    const res = await request(app).get('/api/redemptions');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it('retrieves a single redemption', async () => {
+    const res = await request(app).get(`/api/redemptions/${redemptionId}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id', redemptionId);
+  });
+
+  it('updates a redemption', async () => {
+    const res = await request(app)
+      .put(`/api/redemptions/${redemptionId}`)
+      .send({
+        date: '2024-01-02',
+        source: 'Updated Card',
+        points: 2000,
+        value: 20,
+        taxes: 0,
+        notes: 'updated',
+        is_travel_credit: false
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  it('deletes a redemption', async () => {
+    const res = await request(app).delete(`/api/redemptions/${redemptionId}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- test all backend routes with PostgreSQL
- configure Jest to load DB settings and run in a single worker
- spin up docker-compose in CI and upload coverage to Codecov

## Testing
- `npm test` in `backend`
- `npm test -- --coverage` in `backend`

------
https://chatgpt.com/codex/tasks/task_b_684510f7cdb0832b81750a95ff25a083