### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "pg": "^8.13.1",
     "dotenv": "^16.4.7",
     "multer": "^2.0.1",
-    "csv-parser": "^3.0.0"
+    "csv-parser": "^3.0.0",
+    "express-rate-limit": "^7.5.0"
   },
   "optionalDependencies": {
     "sqlite": "^5.1.1",

--- a/backend/src/routes/import-export.js
+++ b/backend/src/routes/import-export.js
@@ -3,6 +3,7 @@ import { getDb } from '../db.js';
 import multer from 'multer';
 import csv from 'csv-parser';
 import { Readable } from 'stream';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
@@ -188,7 +189,13 @@ router.post('/analyze', upload.single('csvFile'), async (req, res) => {
 });
 
 // Import redemptions from CSV with column mapping
-router.post('/import', upload.any(), async (req, res) => {
+const importRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' }
+});
+
+router.post('/import', importRateLimiter, upload.any(), async (req, res) => {
   // Find the CSV file in the uploaded files
   const file = req.files?.find(f => f.fieldname === 'csvFile' || f.fieldname === 'file');
   if (!file) {


### PR DESCRIPTION
Potential fix for [https://github.com/ayostepht/Cents-Per-Point/security/code-scanning/10](https://github.com/ayostepht/Cents-Per-Point/security/code-scanning/10)

To address the issue, we will implement rate limiting for the `/import` route using the `express-rate-limit` package. This package allows us to define a maximum number of requests that can be made within a specified time window. For example, we can limit the route to accept a maximum of 100 requests per 15 minutes.

Steps to fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter middleware specifically to the `/import` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
